### PR TITLE
Fix for missing resource

### DIFF
--- a/ckanext/geoview/public/webassets.yml
+++ b/ckanext/geoview/public/webassets.yml
@@ -18,7 +18,7 @@ openlayers_css:
     - js/vendor/openlayers/ol.css
     - js/vendor/ol-helpers/ol-helpers.css
 
-geo-resource-styles_css:
+geo-resource-styles:
   output: ckanext-geoview/%(version)s_geo-resource-styles.css
   contents:
     css/geo-resource-styles.css


### PR DESCRIPTION
Fixes the error message:

```
ERROR [ckan.lib.webassets_tools] Trying to include unknown asset: <ckanext-geoview/geo-resource-styles>
```

by matching the original geo-resource-styles name, rather than the _css extension version. 